### PR TITLE
chore: remove MantleBuilder references

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -89,9 +89,6 @@
         <loc>https://docs.assetmantle.one/MantlePlace_Overview/</loc>
     </url>
     <url>
-        <loc>https://docs.assetmantle.one/MantleBuilder_Overview</loc>
-    </url>
-    <url>
         <loc>https://docs.assetmantle.one/Quick_Setup</loc>
     </url>
     <url>
@@ -162,15 +159,6 @@
     </url>
     <url>
         <loc>https://docs.assetmantle.one/assets/images/Mediakit/svg/MantlePlace-Logo-Dark.svg</loc>
-    </url>
-    <url>
-        <loc>https://docs.assetmantle.one/assets/images/Mediakit/svg/MantleBuilder-Logo-Light.svg</loc>
-    </url>
-    <url>
-        <loc>https://docs.assetmantle.one/assets/images/Mediakit/png/MantleBuilder-Logo-Dark.png</loc>
-    </url>
-    <url>
-        <loc>https://docs.assetmantle.one/assets/images/Mediakit/svg/MantleBuilder-Logo-Dark.svg</loc>
     </url>
     <url>
         <loc>https://docs.assetmantle.one/assets/images/Mediakit/png/MantleLabs_Logotype_light.png</loc>


### PR DESCRIPTION
## Summary
- Remove all references to MantleBuilder, the no-code NFT-storefront builder that was never shipped (no live deployment, no `builder.assetmantle.one` DNS record).
- Strips dead nav links, footer entries, sitemap URLs, and docs sections so the public pages no longer point users at a non-existent product.

## Test plan
- [x] `grep -rni "mantlebuilder\|builder\.assetmantle"` in this repo returns no hits
- [x] Edited JS/JSX files parse cleanly via `@babel/parser` with the `jsx` plugin
- [x] Edited JSON / XML files validate via `python3 -c json.load` / `xml.etree.ElementTree.parse`

Generated with Claude Code.